### PR TITLE
Update public instances and main instance url

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,8 +162,8 @@ ___
 ### GitHub
 - **GotHub**
    - Minimalist JS-free Github frontend in Go
-   - [Main Instance](https://gh.odyssey346.dev) | [Repo](https://codeberg.org/gothub/gothub)
-   - [Public Instances](https://codeberg.org/gothub/gothub/wiki/Instances)
+   - [Main Instance](https://gh.bloatcat.tk/) | [Repo](https://codeberg.org/gothub/gothub)
+   - [Public Instances](https://codeberg.org/gothub/gothub#instances)
    - [x] Open-Source
    - [x] Self-Hostable | [Guide](https://codeberg.org/gothub/gothub#setup)
 

--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ ___
 ### GitHub
 - **GotHub**
    - Minimalist JS-free Github frontend in Go
-   - [Main Instance](https://gh.bloatcat.tk/) | [Repo](https://codeberg.org/gothub/gothub)
+   - Main Instance n/a | [Repo](https://codeberg.org/gothub/gothub)
    - [Public Instances](https://codeberg.org/gothub/gothub#instances)
    - [x] Open-Source
    - [x] Self-Hostable | [Guide](https://codeberg.org/gothub/gothub#setup)


### PR DESCRIPTION
## New main instance(as old one died)
https://gh.bloatcat.tk/
## List of public instances is changed to 
https://codeberg.org/gothub/gothub#instances